### PR TITLE
Add support for vulkan dev 525.47.31

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -144,8 +144,8 @@ if [ -z "$_driver_version" ] || [ "$_driver_version" = "latest" ] || [ -z "$_dri
       echo "_driver_version=$_driver_version" >> options
     # This (condition 1) will be treated as the latest Vulkan developer driver.
     else
-      echo '_driver_version=525.47.27' > options
-      echo '_md5sum=a0cb80ac18553a8eed2acb0f30729c48' >> options
+      echo '_driver_version=525.47.31' > options
+      echo '_md5sum=00ec1951b2da0fd026457f880de8a68a' >> options
       echo '_driver_branch=vulkandev' >> options
     fi
 # Package type selector


### PR DESCRIPTION
Vulkan Beta Driver Release Updates
July 11th, 2023 - Windows 532.28, Linux 525.47.31

New:
VK_KHR_cooperative_matrix
VK_EXT_depth_bias_control
VK_EXT_dynamic_rendering_unused_attachments
VK_MESA_video_decode_av1 preliminary implementation for Ada GPUs VK_NV_displacement_micromap updated to version 2
Vulkan video updates:
VK_KHR_video_encode_queue version update 8->9
VK_EXT_video_encode_h264 version update 10->11
Fixes:
Fix for VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT Fix 64-bit shader disk cache issues

https://developer.nvidia.com/vulkan-driver